### PR TITLE
Change Flutter url

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
         <br>All skill levels are welcome. We aim to explore, learn, and share Flutter to the community.
       </p>
       <h2>Visit the official flutter website</h2>
-      <a href="http://bit.ly/flutterph-fluttermain" class="btn">Flutter.io</a>
+      <a href="http://bit.ly/flutterph-fluttermain" class="btn">Flutter.dev</a>
 
       <h2>This site is under development, but you can still catch us on:</h2>
       <a href="http://meetup.com/flutterph" class="btn-small">Meetup Group</a>


### PR DESCRIPTION
Flutter changed its official url from Flutter.io to Flutter.dev for some reason.